### PR TITLE
Bind to parent instead of child element

### DIFF
--- a/wp-content/plugins/manage-wordpress-posts-using-bulk-edit-and-quick-edit/allow-inputs-simple-page-ordering.js
+++ b/wp-content/plugins/manage-wordpress-posts-using-bulk-edit-and-quick-edit/allow-inputs-simple-page-ordering.js
@@ -20,8 +20,7 @@
     }).disableSelection();
 
 // enable text select on inputs
-    sort_container.find("input")
-        .bind('mousedown.ui-disableSelection selectstart.ui-disableSelection', function (e) {
+    sort_container.on('mousedown.ui-disableSelection selectstart.ui-disableSelection', 'input', function (e) {
             e.stopImmediatePropagation();
         });
     sort_container.find("input")


### PR DESCRIPTION
This way, the child can be replaced without needing to rebind the event